### PR TITLE
Always explicitly load the `kpse` module

### DIFF
--- a/lua-uni-normalize.lua
+++ b/lua-uni-normalize.lua
@@ -21,9 +21,9 @@ local char = utf8.char
 local codes = utf8.codes
 local unpack = table.unpack
 
-if tex.initialize then
-  kpse.set_program_name'kpsewhich'
-end
+local kpse = require'kpse'
+kpse.set_program_name'kpsewhich'
+
 local ccc, composition_mapping, decomposition_mapping, compatibility_mapping, nfc_qc do
   local function doubleset(ts, key, v1, kind, v2)
     ts[1][key] = v1

--- a/lua-uni-parse.lua
+++ b/lua-uni-parse.lua
@@ -19,6 +19,9 @@ local lpeg = lpeg or require'lpeg'
 local R = lpeg.R
 local tonumber = tonumber
 
+local kpse = require'kpse'
+kpse.set_program_name'kpsewhich'
+
 local codepoint = lpeg.R('09', 'AF')^4 / function(c) return tonumber(c, 16) end
 local sep = lpeg.P' '^0 * ';' * lpeg.P' '^0
 local codepoint_range = codepoint * ('..' * codepoint + lpeg.Cc(false))


### PR DESCRIPTION
Closes #3.

Compared to the solution given in #3, this solution does not require setting a `kpse` global variable.